### PR TITLE
Add proxypass config option as an environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM debian:jessie
 MAINTAINER Arnulf Heimsakk "arnulf.heimsbakk+docker@gmail.com"
 
 # Will only allow one HTTP port if defined
-# Redirects to first PORT_HTTPS 
+# Redirects to first PORT_HTTPS
 ENV PORT_HTTP 80
 
 # Apache ports, more than one port mapping can be specified with space
@@ -24,7 +24,7 @@ ENV SERVER_NAME localhost
 ENV SERVER_ADMIN webmaster@$SERVER_NAME
 
 # Strict transport age
-ENV SSL_STRICT_TRANSPORT max-age=31536000; includeSubDomains 
+ENV SSL_STRICT_TRANSPORT max-age=31536000; includeSubDomains
 
 # Server SSL chiphers to use
 ENV SSL_CIPHERS EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
@@ -33,6 +33,9 @@ ENV SSL_CIPHERS EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
 ENV SSL_CERT_FILE /etc/ssl/private/cert.pem
 ENV SSL_PRIVKEY_FILE /etc/ssl/private/privkey.pem
 ENV SSL_CHAIN_FILE /etc/ssl/private/chain.pem
+
+# Additional ProxyPass parameters
+ENV PROXYPASS_CONFIG retry=60
 
 # Install apache2 and haveged for entropy
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apache2 openssl haveged && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -51,7 +54,7 @@ RUN a2dissite 000-default
 ADD site-redirect.conf      /etc/apache2/sites-available/redirect.conf
 ADD site-ssl.conf           /etc/apache2/sites-available/ssl.conf
 
-# Generate a a selfsigned certificate just for testing using $SERVER_NAME 
+# Generate a a selfsigned certificate just for testing using $SERVER_NAME
 # as server name; valid for 365 after build of docker
 RUN test -f "$SSL_PRIVKEY_FILE" || echo -n NO\\n.\\n.\\n.\\nWaffle Company Inc\\nBranding\\n$SERVER_NAME\\n$SERVER_ADMIN\\n | openssl req -x509 -newkey rsa:4096 -sha256 -keyout "$SSL_PRIVKEY_FILE" -out "$SSL_CERT_FILE" -days 365 -nodes && ln -s "$SSL_CERT_FILE" "$SSL_CHAIN_FILE"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https-proxy terminates a HTTPS connection for a linked dockers unencrypted web s
 
 This docker is configured to get **A+** on [sslabs.com](https://www.ssllabs.com/ssltest/).
 
-**aheimsbakk/https-proxy** is continuance of deprecated *[aheimsbakk/ssl-proxy](https://hub.docker.com/r/aheimsbakk/ssl-proxy/)* 
+**aheimsbakk/https-proxy** is continuance of deprecated *[aheimsbakk/ssl-proxy](https://hub.docker.com/r/aheimsbakk/ssl-proxy/)*
 
 ## Tags
 
@@ -23,7 +23,7 @@ This docker is configured to get **A+** on [sslabs.com](https://www.ssllabs.com/
 		RequestHeader unset Proxy early
 
 ## Changelog
- 
+
 * 3.1: Give the application a hint that it receives connection from a ssl proxy.
 
         RequestHeader set X-Forwarded-Proto "https"
@@ -136,6 +136,10 @@ Create a cronjob to keep your letsencrypt.org certificate up to date with someth
 * `SSL_CHAIN_FILE` - name of certificate chain file
 
 	default: `/etc/ssl/private/chain.pem`
+
+* `PROXYPASS_CONFIG` - Additional configuration for the ProxyPass directive.  See [the Apache Proxypass documentation](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxypass).
+
+    default: `retry=60`
 
 ## Volumes
 

--- a/site-ssl.conf
+++ b/site-ssl.conf
@@ -1,6 +1,6 @@
-SSLUseStapling on 
-SSLStaplingCache "shmcb:logs/stapling-cache(150000)" 
-SSLStaplingResponseMaxAge 900 
+SSLUseStapling on
+SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
+SSLStaplingResponseMaxAge 900
 
 <VirtualHost *:%PORT_HTTPS%>
     ServerAdmin ${SERVER_ADMIN}
@@ -34,7 +34,7 @@ SSLStaplingResponseMaxAge 900
     RequestHeader set X-Forwarded-Proto "https"
 
     ProxyPreserveHost on
-    ProxyPass / http://http:%PORT_REDIRECT%/
+    ProxyPass / http://http:%PORT_REDIRECT%/ ${PROXYPASS_CONFIG}
     ProxyPassReverse / http://http:%PORT_REDIRECT%/
 
     LogLevel warn


### PR DESCRIPTION
I'm afraid my editor trimmed some trailing whitespaces on a few lines, making this look like more of a change than it is.

The important bit is the PROXYPASS_CONFIG environment variable, and the change to the site-ssl.conf file to add it to the ProxyPass directive.

Note that the retry=60 default value is just repeating what the Apache default value is, so there's no behavior change by default.